### PR TITLE
Fixing an if statement with wrong logic introduced in last commit.

### DIFF
--- a/Maintenance Events/src/com/infiniteautomation/mango/spring/service/maintenanceEvents/MaintenanceEventsService.java
+++ b/Maintenance Events/src/com/infiniteautomation/mango/spring/service/maintenanceEvents/MaintenanceEventsService.java
@@ -223,7 +223,7 @@ public class MaintenanceEventsService extends AbstractVOService<MaintenanceEvent
                 return;
             }else {
                 if(read) {
-                    if(dataPointService.hasReadPermission(user,point)) {
+                    if(!dataPointService.hasReadPermission(user,point)) {
                         hasPermission.setFalse();
                     }
                 }else {


### PR DESCRIPTION
RAD-971

By mistake, In my last commit I changed the logic in an if statement introducing a bug that made the permissions to return the wrong result when requesting read permissions in the MaintenanceEventService class