### PR TITLE
Fixing issue when trying to deserialize a Blob object.

### DIFF
--- a/SQL console/src/com/serotonin/m2m2/db/dao/SqlConsole.java
+++ b/SQL console/src/com/serotonin/m2m2/db/dao/SqlConsole.java
@@ -4,7 +4,6 @@
 
 package com.serotonin.m2m2.db.dao;
 
-import java.sql.Blob;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.Types;
@@ -12,13 +11,14 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.sql.rowset.serial.SerialBlob;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.StatementCallback;
 import org.springframework.stereotype.Component;
 
 import com.infiniteautomation.mango.rest.latest.SqlQueryResult;
 import com.serotonin.db.spring.ExtendedJdbcTemplate;
-import com.serotonin.util.SerializationHelper;
 
 @Component
 public class SqlConsole {
@@ -50,13 +50,8 @@ public class SqlConsole {
                         row.add(rs.getString(i + 1));
                     else if (meta.getColumnType(i + 1) == Types.LONGVARBINARY
                             || meta.getColumnType(i + 1) == Types.BLOB) {
-                        Blob blob = rs.getBlob(i + 1);
-                        Object o;
-                        if (blob == null)
-                            o = null;
-                        else
-                            o = SerializationHelper.readObjectInContext(blob.getBinaryStream());
-                        row.add(serializedDataMsg + "(" + o + ")");
+                        SerialBlob blob = new SerialBlob( rs.getBlob(i + 1) );
+                        row.add(serializedDataMsg + "(" + blob + ")");
                     } else
                         row.add(rs.getObject(i + 1));
                 }


### PR DESCRIPTION
This is for this ticket  https://radixiot.atlassian.net/browse/RAD-2620. The previous code was trying to recreate a Blob object from the content of a Blob object (not the serialized Blob object). That is why when it tries to recreate it it throws this error:

com.serotonin.ShouldNeverHappenException: java.io.StreamCorruptedException: invalid stream header: 73656C65
	at com.serotonin.util.SerializationHelper.readObjectInContext(SerializationHelper.java:93) ~[mango-4.3.0.jar:?]

With the change, the code can now recreate a Blob object using the content stored in the database., and now it returns the result of toString() method of the object which is this:

javax.sql.rowset.serial.SerialBlob@c1ec5370

and the value that will be shown for that column will be something like:

Serialized data (javax.sql.rowset.serial.SerialBlob@c1ec5370)

I think that makes sense because Blobs are usually meant to store large content of bytes content and not readable values.
