### PR TITLE
Allow setting published point names when saving publisher via REST

### DIFF
--- a/Mango API/RELEASE-NOTES
+++ b/Mango API/RELEASE-NOTES
@@ -1,3 +1,6 @@
+*Version 4.5.1*
+* publisher/{xid} POST, PUT, PATCH methods now allows setting published point names if provided
+
 *Version 4.5.0*
 * Upgraded for Mango 4.5.0
 

--- a/Mango API/src/com/infiniteautomation/mango/rest/latest/PublishersRestController.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/latest/PublishersRestController.java
@@ -257,7 +257,9 @@ public class PublishersRestController {
                 if(StringUtils.isEmpty(pm.getXid())) {
                     pm.setXid(publishedPointService.generateUniqueXid());
                 }
-                pm.setName(publisherVO.getName() + " point " + i);
+                if (StringUtils.isEmpty(pm.getName())) {
+                    pm.setName(publisherVO.getName() + " point " + i);
+                }
                 pm.setEnabled(true);
                 i++;
                 publishedPointService.insert(unmapPoint.apply(pm, user));


### PR DESCRIPTION
## Description

https://radixiot.atlassian.net/browse/RAD-2657
UDMI published points have lower camel case validation which require this change in order to save points with publisher

## Current behavior

Published point names constant and auto generated if they are created with publisher.

Example:
* Publisher point 0
* Publisher point 1

## Expected behavior
* Published point names should be generated if they are not provided.