### PR TITLE
RAD-4040_4.5.2: Backporting RAD-4040 to 4.5.2

### DIFF
--- a/Mango API/RELEASE-NOTES
+++ b/Mango API/RELEASE-NOTES
@@ -1,3 +1,6 @@
+*Version 4.5.2*
+* Fix to allow users to see comments for active alarms in real-time
+
 *Version 4.5.1*
 * publisher/{xid} POST, PUT, PATCH methods now allows setting published point names if provided
 * New properties added for System Action task and resource lifetime (SystemActionTemporaryResource) rest.systemAction.expirationPeriods default is 1 and rest.systemAction.expirationPeriodType default is WEEKS

--- a/Mango API/src/com/infiniteautomation/mango/rest/latest/websocket/dao/UserCommentWebSocketHandler.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/latest/websocket/dao/UserCommentWebSocketHandler.java
@@ -1,8 +1,9 @@
 /*
- * Copyright (C) 2021 Radix IoT LLC. All rights reserved.
+ * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
  */
 package com.infiniteautomation.mango.rest.latest.websocket.dao;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -11,6 +12,7 @@ import com.infiniteautomation.mango.rest.latest.model.comment.UserCommentModel;
 import com.infiniteautomation.mango.rest.latest.websocket.DaoNotificationWebSocketHandler;
 import com.infiniteautomation.mango.rest.latest.websocket.WebSocketMapping;
 import com.infiniteautomation.mango.spring.events.DaoEvent;
+import com.infiniteautomation.mango.spring.service.UserCommentService;
 import com.serotonin.m2m2.vo.comment.UserCommentVO;
 import com.serotonin.m2m2.vo.permission.PermissionHolder;
 
@@ -21,13 +23,16 @@ import com.serotonin.m2m2.vo.permission.PermissionHolder;
 @Component
 @WebSocketMapping("/websocket/user-comments")
 public class UserCommentWebSocketHandler extends DaoNotificationWebSocketHandler<UserCommentVO>{
+    private final UserCommentService service;
+
+    @Autowired
+    public UserCommentWebSocketHandler(UserCommentService service) {
+        this.service = service;
+    }
 
     @Override
     protected boolean hasPermission(PermissionHolder user, UserCommentVO vo) {
-        if (permissionService.hasAdminRole(user)) {
-            return true;
-        }
-        return user.getUser() != null && user.getUser().getId() == vo.getUserId();
+        return service.hasReadPermission(user, vo);
     }
 
     @Override


### PR DESCRIPTION
## Description

In the Active Alarms page, the Compass LDAP users cannot see the Comments related to the new alarms that are appearing in real-time in the screen, so these changes introduce a fix to allow users to see comments for active alarms in real-time. Websocket tests have been added to be able to test it through node js tests
https://radixiot.atlassian.net/browse/RAD-4040

## Current behavior

In the Active Alarms page, the Compass LDAP users cannot see the Comments related to the new alarms that are appearing in real-time in the screen. But the Superadmin users can see Comments in real-time.

## Expected behavior
- Users can see the comments in real-time

## Changes
- Fix on UserCommentService and  UserCommentWebSocketHandler to allow users to see comments in real-time

## Resources
-

## Tests
NodeJS tests where added: 
- Websocket notifications for comments for DPs with role user and User with role user
- User should not have received any web socket messages

## Release Notes
Yes (on the ticket)

