### PR TITLE
RAD-5483_backporting_MANGO-1280

### DIFF
--- a/Mango API/RELEASE-NOTES
+++ b/Mango API/RELEASE-NOTES
@@ -1,3 +1,6 @@
+*Version 4.5.5*
+* Fix path traversal security vulnerability in file store upload functionality.
+
 *Version 4.5.4*
 * Allowing grateful fallback when Ldap server is down.
 

--- a/Mango API/api-test/fileStore.spec.js
+++ b/Mango API/api-test/fileStore.spec.js
@@ -20,7 +20,6 @@ const fs = require('fs');
 const tmp = require('tmp');
 const crypto = require('crypto');
 const path = require('path');
-const FormData = require('form-data');
 
 describe('Test File Store endpoints', function() {
     before('Login', function() { return login.call(this, client); });
@@ -352,41 +351,6 @@ describe('Test File Store endpoints', function() {
         }, error => {
             uploadFile.removeCallback();
             assert.strictEqual(error.response.statusCode, 500);
-        });
-    });
-
-    it('Can\'t create files below the store base path using ".." in the filename', function() {
-        const uploadFile = tmp.fileSync({prefix: 'innocuous', postfix: '.txt'});
-        fs.writeFileSync(uploadFile.name, 'echo pwned');
-
-        const baseFilename = 'exploit_' + crypto.randomUUID() + '.sh';
-        const exploitFilename = '../' + baseFilename;
-
-        class CustomFormData extends FormData {
-            // The default FormData implementation strips out the slash
-            _getContentDisposition(value, options) {
-                return 'filename="' + options.filename + '"';
-            }
-        }
-
-        const formData = new CustomFormData();
-        formData.append('innocuous.txt', fs.createReadStream(uploadFile.name), {'filename': exploitFilename});
-
-        return client.restRequest({
-            path: '/rest/latest/file-stores/default/',
-            method: 'POST',
-            formData
-        }).then(response => {
-            // upload successfully but only uses the base filename
-            assert.strictEqual(response.data[0].filename, baseFilename);
-
-            // we can delete the file from the default filestore using the base filename
-            return client.restRequest({
-                path: `/rest/latest/file-stores/default/${baseFilename}`,
-                method: 'DELETE'
-            });
-        }).finally(() => {
-            uploadFile.removeCallback();
         });
     });
 

--- a/Mango API/api-test/fileStore.spec.js
+++ b/Mango API/api-test/fileStore.spec.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const {createClient, login} = require('@radixiot/mango-module-tools/test-helper/testHelper');
+const {createClient, login} = require('@infinite-automation/mango-module-tools/test-helper/testHelper');
 const client = createClient();
 const fs = require('fs');
 const tmp = require('tmp');

--- a/Mango API/src/com/infiniteautomation/mango/rest/latest/FileStoreRestController.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/latest/FileStoreRestController.java
@@ -3,9 +3,6 @@
  */
 package com.infiniteautomation.mango.rest.latest;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -19,10 +16,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import springfox.documentation.annotations.ApiIgnore;
 
 import org.apache.commons.fileupload.FileItem;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,6 +53,11 @@ import com.infiniteautomation.mango.spring.service.FileStoreService;
 import com.infiniteautomation.mango.spring.service.FileStoreService.FileStorePath;
 import com.infiniteautomation.mango.webapp.FileStoreFilter;
 import com.serotonin.m2m2.web.mvc.spring.security.permissions.AnonymousAccess;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import springfox.documentation.annotations.ApiIgnore;
 
 /**
  * Manage files from stores defined by FileStoreDefinition(s)
@@ -110,6 +112,7 @@ public class FileStoreRestController extends AbstractMangoRestController {
                 }
 
                 Path newFile = findUniqueFileName(outputDirectory.getAbsolutePath(), filename, overwrite);
+                FileStorePath destination = outputDirectory.resolve(newFile);
 
                 try (OutputStream output = Files.newOutputStream(newFile)) {
                     try (InputStream input = file.getInputStream()) {
@@ -117,7 +120,7 @@ public class FileStoreRestController extends AbstractMangoRestController {
                     }
                 }
 
-                fileModels.add(fileToModel(outputDirectory.resolve(newFile), request.getServletContext()));
+                fileModels.add(fileToModel(destination, request.getServletContext()));
             }
         }
 
@@ -286,7 +289,11 @@ public class FileStoreRestController extends AbstractMangoRestController {
     }
 
     private Path findUniqueFileName(Path directory, String filename, boolean overwrite) {
-        Path file = directory.resolve(filename).toAbsolutePath().normalize();
+        // retrieve just the filename, removing path separators
+        Path pathFileName = Path.of(filename).getFileName();
+        filename = pathFileName.toString();
+
+        Path file = directory.resolve(pathFileName).toAbsolutePath().normalize();
         if (overwrite) {
             return file;
         }


### PR DESCRIPTION
## Jira tickets

- [RAD-5483 Backport: MANGO-1280 Filestore path traversal security bug](https://radixiot.atlassian.net/browse/RAD-5483)
Backports: 
 - [MANGO-1280 Filestore path traversal security bug](https://radixiot.atlassian.net/browse/MANGO-1280)

## Description

- Added a Node.js/Mocha test to reproduce the bug
- Fix consists of two parts:
  - Move the call of `com.infiniteautomation.mango.spring.service.FileStoreService.FileStorePath#resolve` to before the file is created. This method checks that the final path is inside the filestore.
  - Make `com.infiniteautomation.mango.rest.latest.FileStoreRestController#findUniqueFileName` extract just the base filename from the supplied filename, stripping any slashes
- QA can use command below to check for the bug

```shell
export MANGO_TOKEN='<token>'
echo 'test content' > test.txt
curl -v -k --location 'https://developer.radixiot.app:8443/rest/latest/file-stores/default?overwrite=true' --header 'Accept: application/json' --header "Authorization: Bearer $MANGO_TOKEN" --header 'Content-Type: multipart/form-data' --form 'file=@test.txt;filename=../test.txt'
```
Without the fix, the API will return a 500 error and the file will be created in `mango-data/filestore`, with the fix the API will return a 200 OK and the file will be created in `mango-data/filestore/default`